### PR TITLE
Textures : Increase the amount of VRAM Cache available for Textures based on selected DRAM.

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -152,16 +152,17 @@ namespace Ryujinx.Graphics.Gpu
         /// Creates a new GPU memory manager.
         /// </summary>
         /// <param name="pid">ID of the process that owns the memory manager</param>
+        /// <param name="cpuMemorySize">The amount of physical CPU Memory Avaiable on the device.</param>
         /// <returns>The memory manager</returns>
         /// <exception cref="ArgumentException">Thrown when <paramref name="pid"/> is invalid</exception>
-        public MemoryManager CreateMemoryManager(ulong pid)
+        public MemoryManager CreateMemoryManager(ulong pid, ulong cpuMemorySize)
         {
             if (!PhysicalMemoryRegistry.TryGetValue(pid, out var physicalMemory))
             {
                 throw new ArgumentException("The PID is invalid or the process was not registered", nameof(pid));
             }
 
-            return new MemoryManager(physicalMemory);
+            return new MemoryManager(physicalMemory, cpuMemorySize);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -104,7 +104,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _maxCacheMemoryUsage = Math.Clamp(cacheMemory, MinTextureSizeCapacity, MaxTextureSizeCapacity);
 
-            Logger.Info?.Print(LogClass.ServiceNv, $"AutoDelete Cache Allocated VRAM : {_maxCacheMemoryUsage / GiB} GiB");
+            Logger.Info?.Print(LogClass.Gpu, $"AutoDelete Cache Allocated VRAM : {_maxCacheMemoryUsage / GiB} GiB");
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -47,11 +48,17 @@ namespace Ryujinx.Graphics.Gpu.Image
     {
         private const int MinCountForDeletion = 32;
         private const int MaxCapacity = 2048;
+        private const ulong GiB = 1024 * 1024 * 1024;
+        private ulong MaxTextureSizeCapacity = 4UL * GiB;
         private const ulong MinTextureSizeCapacity = 512 * 1024 * 1024;
-        private const ulong MaxTextureSizeCapacity = 4UL * 1024 * 1024 * 1024;
-        private const ulong DefaultTextureSizeCapacity = 1UL * 1024 * 1024 * 1024;
+        private const ulong DefaultTextureSizeCapacity = 1 * GiB;
+        private const ulong TextureSizeCapacity6GiB = 4 * GiB;
+        private const ulong TextureSizeCapacity8GiB = 6 * GiB;
+        private const ulong TextureSizeCapacity12GiB = 12 * GiB;
+
+
         private const float MemoryScaleFactor = 0.50f;
-        private ulong _maxCacheMemoryUsage = 0;
+        private ulong _maxCacheMemoryUsage = DefaultTextureSizeCapacity;
 
         private readonly LinkedList<Texture> _textures;
         private ulong _totalSize;
@@ -66,18 +73,38 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <remarks>
         /// If the backend GPU has 0 memory capacity, the cache size defaults to `DefaultTextureSizeCapacity`.
+        /// 
+        /// Reads the current Device total CPU Memory, to determine the maximum amount of Vram available. Capped to 50% of Current GPU Memory.
         /// </remarks>
         /// <param name="context">The GPU context that the cache belongs to</param>
-        public void Initialize(GpuContext context)
+        /// <param name="cpuMemorySize">The amount of physical CPU Memory Avaiable on the device.</param>
+        public void Initialize(GpuContext context, ulong cpuMemorySize)
         {
+            var cpuMemorySizeGiB = cpuMemorySize / GiB;
+
+            if (cpuMemorySizeGiB < 6 || context.Capabilities.MaximumGpuMemory == 0)
+            {
+                _maxCacheMemoryUsage = DefaultTextureSizeCapacity;
+                return;
+            }
+            else if (cpuMemorySizeGiB == 6)
+            {
+                MaxTextureSizeCapacity = TextureSizeCapacity6GiB;
+            }
+            else if (cpuMemorySizeGiB == 8)
+            {
+                MaxTextureSizeCapacity = TextureSizeCapacity8GiB;
+            }
+            else
+            {
+                MaxTextureSizeCapacity = TextureSizeCapacity12GiB;
+            }
+
             var cacheMemory = (ulong)(context.Capabilities.MaximumGpuMemory * MemoryScaleFactor);
 
             _maxCacheMemoryUsage = Math.Clamp(cacheMemory, MinTextureSizeCapacity, MaxTextureSizeCapacity);
 
-            if (context.Capabilities.MaximumGpuMemory == 0)
-            {
-                _maxCacheMemoryUsage = DefaultTextureSizeCapacity;
-            }
+            Logger.Info?.Print(LogClass.ServiceNv, $"AutoDelete Cache Allocated VRAM : {_maxCacheMemoryUsage / GiB} GiB");
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -71,9 +71,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Initializes the cache, setting the maximum texture capacity for the specified GPU context.
         /// </summary>
-        public void Initialize()
+        /// <param name="cpuMemorySize">The amount of physical CPU Memory Avaiable on the device.</param>
+        public void Initialize(ulong cpuMemorySize)
         {
-            _cache.Initialize(_context);
+            _cache.Initialize(_context, cpuMemorySize);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -55,7 +55,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Creates a new instance of the GPU memory manager.
         /// </summary>
         /// <param name="physicalMemory">Physical memory that this memory manager will map into</param>
-        internal MemoryManager(PhysicalMemory physicalMemory)
+        /// <param name="cpuMemorySize">The amount of physical CPU Memory Avaiable on the device.</param>
+        internal MemoryManager(PhysicalMemory physicalMemory, ulong cpuMemorySize)
         {
             Physical = physicalMemory;
             VirtualRangeCache = new VirtualRangeCache(this);
@@ -65,7 +66,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             MemoryUnmapped += Physical.BufferCache.MemoryUnmappedHandler;
             MemoryUnmapped += VirtualRangeCache.MemoryUnmappedHandler;
             MemoryUnmapped += CounterCache.MemoryUnmappedHandler;
-            Physical.TextureCache.Initialize();
+            Physical.TextureCache.Initialize(cpuMemorySize);
         }
 
         /// <summary>

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 
         public NvHostAsGpuDeviceFile(ServiceCtx context, IVirtualMemoryManager memory, ulong owner) : base(context, owner)
         {
-            _asContext = new AddressSpaceContext(context.Device.Gpu.CreateMemoryManager(owner));
+            _asContext = new AddressSpaceContext(context.Device.Gpu.CreateMemoryManager(owner, context.Device.Memory.Size));
             _memoryAllocator = new NvMemoryAllocator();
         }
 


### PR DESCRIPTION
### AutoCacheDelete Continuation of my previous Ryujinx commit from September on the Original Ryujinx Project.

- If the device has less than 6GiB CPU Ram Allocated it'll default to : 1 GiB VRAM allocated
- for 6GiB CPU ram it'll cap to allowed 4 GiB VRAM allocated
- for 8GiB CPU ram it'll cap to allowed 6 GiB VRAM allocated
- for 12GiB CPU ram it'll cap to allowed 12 GiB VRAM allocated
- This also adds a log with the amount of VRAM allocated in GiB.

## What these changes aim to Improve : 
- Fixes a crash on Luigi Mansion 3, due to the amount of VRAM the game uses, from the previous commit the game would crash at 2X or higher scaled resolution on GPUS with less than 12GB of VRAM. Using the 4GiB CPU Dram setting will now default to 1 GiB of VRAM eliminating issues such as this.
- This change also doesn't affect Internal resolution mods, as they can only go up to 1440p with 4GiB of Dram.
- Bumping the maximum amount of VRAM available for 8GiB DRAM should allow some 4k or higher internal resolution mods to run better on higher end GPU's, keep in mind the VRAM is still capped to 50% of the current GPU available Memory.
- For 12GiB the cap has been made even higher, the 12GiB setting should only be used when using Resolution + Texture Mods or extreme Resolution mods, this is where more Texture VRAM can be beneficial on extremely high end GPU's.


Keep in mind these caps are still only the upper limit of what amount of VRAM can be allocated towards textures, as it'll always be capped to 50% of the GPU's Memory.

### Side Notes:
- DRAM Size context should be updated to factor in these changes in a later commit.