### PR TITLE
Ava UI : Set the Default Controller to Pro Controller.

### DIFF
--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -898,7 +898,7 @@ namespace Ryujinx.UI.Common.Configuration
                     Backend = InputBackendType.WindowKeyboard,
                     Id = "0",
                     PlayerIndex = PlayerIndex.Player1,
-                    ControllerType = ControllerType.JoyconPair,
+                    ControllerType = ControllerType.ProController,
                     LeftJoycon = new LeftJoyconCommonConfig<Key>
                     {
                         DpadUp = Key.Up,

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -1128,7 +1128,7 @@ namespace Ryujinx.UI.Common.Configuration
                         Backend = InputBackendType.WindowKeyboard,
                         Id = "0",
                         PlayerIndex = PlayerIndex.Player1,
-                        ControllerType = ControllerType.JoyconPair,
+                        ControllerType = ControllerType.ProController,
                         LeftJoycon = new LeftJoyconCommonConfig<Key>
                         {
                             DpadUp = Key.Up,


### PR DESCRIPTION
- Let's be honest nobody is using JoyCon pair on their PC.
- It looks nicer and more accurate to more traditional controllers.
- Fixes issues with UltraCam mods and other such mods with lack of proper Dual Joycon support.