### PR TITLE
Remove 'Enter' hotkey in settings menu

### DIFF
--- a/src/Ryujinx/UI/Windows/SettingsWindow.axaml
+++ b/src/Ryujinx/UI/Windows/SettingsWindow.axaml
@@ -109,7 +109,6 @@
             HorizontalAlignment="Right"
             ReverseOrder="{Binding IsMacOS}">
             <Button
-                HotKey="Enter"
                 Classes="accent"
                 Content="{locale:Locale SettingsButtonOk}"
                 Command="{Binding OkButton}" />


### PR DESCRIPTION
This allows the Enter key to be bound to a button when using the Avalonia UI.