### PR TITLE
Add option to show the title bar

### DIFF
--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.UI.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 55;
+        public const int CurrentVersion = 56;
 
         /// <summary>
         /// Version of the configuration file format
@@ -172,6 +172,11 @@ namespace Ryujinx.UI.Common.Configuration
         /// Enables or disables save window size, position and state on close.
         /// </summary>
         public bool RememberWindowState { get; set; }
+
+        /// <summary>
+        /// Enables or disables the redesigned title bar
+        /// </summary>
+        public bool ShowTitleBar { get; set; }
 
         /// <summary>
         /// Enables hardware-accelerated rendering for Avalonia

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -653,6 +653,11 @@ namespace Ryujinx.UI.Common.Configuration
         public ReactiveObject<bool> RememberWindowState { get; private set; }
 
         /// <summary>
+        /// Enables or disables the redesigned title bar
+        /// </summary>
+        public ReactiveObject<bool> ShowTitleBar { get; private set; }
+
+        /// <summary>
         /// Enables hardware-accelerated rendering for Avalonia
         /// </summary>
         public ReactiveObject<bool> EnableHardwareAcceleration { get; private set; }
@@ -675,6 +680,7 @@ namespace Ryujinx.UI.Common.Configuration
             ShowConfirmExit = new ReactiveObject<bool>();
             IgnoreApplet = new ReactiveObject<bool>();
             RememberWindowState = new ReactiveObject<bool>();
+            ShowTitleBar = new ReactiveObject<bool>();
             EnableHardwareAcceleration = new ReactiveObject<bool>();
             HideCursor = new ReactiveObject<HideCursorMode>();
         }
@@ -714,6 +720,7 @@ namespace Ryujinx.UI.Common.Configuration
                 ShowConfirmExit = ShowConfirmExit,
                 IgnoreApplet = IgnoreApplet,
                 RememberWindowState = RememberWindowState,
+                ShowTitleBar = ShowTitleBar,
                 EnableHardwareAcceleration = EnableHardwareAcceleration,
                 HideCursor = HideCursor,
                 EnableVsync = Graphics.EnableVsync,
@@ -826,6 +833,7 @@ namespace Ryujinx.UI.Common.Configuration
             ShowConfirmExit.Value = true;
             IgnoreApplet.Value = false;
             RememberWindowState.Value = true;
+            ShowTitleBar.Value = false;
             EnableHardwareAcceleration.Value = true;
             HideCursor.Value = HideCursorMode.OnIdle;
             Graphics.EnableVsync.Value = true;
@@ -1540,6 +1548,15 @@ namespace Ryujinx.UI.Common.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 56)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 56.");
+
+                configurationFileFormat.ShowTitleBar = false;
+
+                configurationFileUpdated = true;
+            }
+
             Logger.EnableFileLog.Value = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value = configurationFileFormat.ResScaleCustom;
@@ -1572,6 +1589,7 @@ namespace Ryujinx.UI.Common.Configuration
             ShowConfirmExit.Value = configurationFileFormat.ShowConfirmExit;
             IgnoreApplet.Value = configurationFileFormat.IgnoreApplet;
             RememberWindowState.Value = configurationFileFormat.RememberWindowState;
+            ShowTitleBar.Value = configurationFileFormat.ShowTitleBar;
             EnableHardwareAcceleration.Value = configurationFileFormat.EnableHardwareAcceleration;
             HideCursor.Value = configurationFileFormat.HideCursor;
             Graphics.EnableVsync.Value = configurationFileFormat.EnableVsync;

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -1552,7 +1552,7 @@ namespace Ryujinx.UI.Common.Configuration
             {
                 Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 56.");
 
-                configurationFileFormat.ShowTitleBar = (OperatingSystem.IsWindows()) ? false : true;
+                configurationFileFormat.ShowTitleBar = !OperatingSystem.IsWindows();
 
                 configurationFileUpdated = true;
             }

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -1552,7 +1552,7 @@ namespace Ryujinx.UI.Common.Configuration
             {
                 Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 56.");
 
-                configurationFileFormat.ShowTitleBar = false;
+                configurationFileFormat.ShowTitleBar = (OperatingSystem.IsWindows()) ? false : true;
 
                 configurationFileUpdated = true;
             }

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -833,7 +833,7 @@ namespace Ryujinx.UI.Common.Configuration
             ShowConfirmExit.Value = true;
             IgnoreApplet.Value = false;
             RememberWindowState.Value = true;
-            ShowTitleBar.Value = false;
+            ShowTitleBar.Value = (OperatingSystem.IsWindows()) ? false : true;
             EnableHardwareAcceleration.Value = true;
             HideCursor.Value = HideCursorMode.OnIdle;
             Graphics.EnableVsync.Value = true;

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -833,7 +833,7 @@ namespace Ryujinx.UI.Common.Configuration
             ShowConfirmExit.Value = true;
             IgnoreApplet.Value = false;
             RememberWindowState.Value = true;
-            ShowTitleBar.Value = (OperatingSystem.IsWindows()) ? false : true;
+            ShowTitleBar.Value = !OperatingSystem.IsWindows();
             EnableHardwareAcceleration.Value = true;
             HideCursor.Value = HideCursorMode.OnIdle;
             Graphics.EnableVsync.Value = true;

--- a/src/Ryujinx/Assets/Locales/ar_SA.json
+++ b/src/Ryujinx/Assets/Locales/ar_SA.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "التحقق من وجود تحديثات عند التشغيل",
   "SettingsTabGeneralShowConfirmExitDialog": "إظهار مربع حوار \"تأكيد الخروج\"",
   "SettingsTabGeneralRememberWindowState": "تذكر حجم/موضع النافذة",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "إخفاء المؤشر:",
   "SettingsTabGeneralHideCursorNever": "مطلقا",
   "SettingsTabGeneralHideCursorOnIdle": "عند الخمول",

--- a/src/Ryujinx/Assets/Locales/de_DE.json
+++ b/src/Ryujinx/Assets/Locales/de_DE.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Beim Start nach Updates suchen",
   "SettingsTabGeneralShowConfirmExitDialog": "Zeige den \"Beenden bestätigen\"-Dialog",
   "SettingsTabGeneralRememberWindowState": "Fenstergröße/-position merken",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Mauszeiger ausblenden",
   "SettingsTabGeneralHideCursorNever": "Niemals",
   "SettingsTabGeneralHideCursorOnIdle": "Mauszeiger bei Inaktivität ausblenden",

--- a/src/Ryujinx/Assets/Locales/el_GR.json
+++ b/src/Ryujinx/Assets/Locales/el_GR.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Έλεγχος για Ενημερώσεις στην Εκκίνηση",
   "SettingsTabGeneralShowConfirmExitDialog": "Εμφάνιση διαλόγου \"Επιβεβαίωση Εξόδου\".",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Απόκρυψη Κέρσορα:",
   "SettingsTabGeneralHideCursorNever": "Ποτέ",
   "SettingsTabGeneralHideCursorOnIdle": "Απόκρυψη Δρομέα στην Αδράνεια",

--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -100,6 +100,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Check for Updates on Launch",
   "SettingsTabGeneralShowConfirmExitDialog": "Show \"Confirm Exit\" Dialog",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Hide Cursor:",
   "SettingsTabGeneralHideCursorNever": "Never",
   "SettingsTabGeneralHideCursorOnIdle": "On Idle",

--- a/src/Ryujinx/Assets/Locales/es_ES.json
+++ b/src/Ryujinx/Assets/Locales/es_ES.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Buscar actualizaciones al iniciar",
   "SettingsTabGeneralShowConfirmExitDialog": "Mostrar diálogo de confirmación al cerrar",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Esconder el cursor:",
   "SettingsTabGeneralHideCursorNever": "Nunca",
   "SettingsTabGeneralHideCursorOnIdle": "Ocultar cursor cuando esté inactivo",

--- a/src/Ryujinx/Assets/Locales/fr_FR.json
+++ b/src/Ryujinx/Assets/Locales/fr_FR.json
@@ -100,6 +100,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Vérifier les mises à jour au démarrage",
   "SettingsTabGeneralShowConfirmExitDialog": "Afficher le message de \"Confirmation de sortie\"",
   "SettingsTabGeneralRememberWindowState": "Mémoriser la taille/position de la fenêtre",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Masquer le Curseur :",
   "SettingsTabGeneralHideCursorNever": "Jamais",
   "SettingsTabGeneralHideCursorOnIdle": "Masquer le curseur si inactif",

--- a/src/Ryujinx/Assets/Locales/he_IL.json
+++ b/src/Ryujinx/Assets/Locales/he_IL.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "בדוק אם קיימים עדכונים בהפעלה",
   "SettingsTabGeneralShowConfirmExitDialog": "הראה דיאלוג \"אשר יציאה\"",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "הסתר את הסמן",
   "SettingsTabGeneralHideCursorNever": "אף פעם",
   "SettingsTabGeneralHideCursorOnIdle": "במצב סרק",

--- a/src/Ryujinx/Assets/Locales/it_IT.json
+++ b/src/Ryujinx/Assets/Locales/it_IT.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Controlla aggiornamenti all'avvio",
   "SettingsTabGeneralShowConfirmExitDialog": "Mostra dialogo \"Conferma Uscita\"",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Nascondi il cursore:",
   "SettingsTabGeneralHideCursorNever": "Mai",
   "SettingsTabGeneralHideCursorOnIdle": "Quando è inattivo",

--- a/src/Ryujinx/Assets/Locales/ja_JP.json
+++ b/src/Ryujinx/Assets/Locales/ja_JP.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "起動時にアップデートを確認する",
   "SettingsTabGeneralShowConfirmExitDialog": "\"終了を確認\" ダイアログを表示する",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "マウスカーソルを非表示",
   "SettingsTabGeneralHideCursorNever": "決して",
   "SettingsTabGeneralHideCursorOnIdle": "アイドル時",

--- a/src/Ryujinx/Assets/Locales/ko_KR.json
+++ b/src/Ryujinx/Assets/Locales/ko_KR.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "시작 시, 업데이트 확인",
   "SettingsTabGeneralShowConfirmExitDialog": "\"종료 확인\" 대화 상자 표시",
   "SettingsTabGeneralRememberWindowState": "창 크기/위치 기억",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "마우스 커서 숨기기",
   "SettingsTabGeneralHideCursorNever": "절대 안 함",
   "SettingsTabGeneralHideCursorOnIdle": "유휴 상태",

--- a/src/Ryujinx/Assets/Locales/pl_PL.json
+++ b/src/Ryujinx/Assets/Locales/pl_PL.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Sprawdzaj aktualizacje przy uruchomieniu",
   "SettingsTabGeneralShowConfirmExitDialog": "Pokazuj okno dialogowe \"Potwierdź wyjście\"",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Ukryj kursor:",
   "SettingsTabGeneralHideCursorNever": "Nigdy",
   "SettingsTabGeneralHideCursorOnIdle": "Gdy bezczynny",

--- a/src/Ryujinx/Assets/Locales/pt_BR.json
+++ b/src/Ryujinx/Assets/Locales/pt_BR.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Verificar se há atualizações ao iniciar",
   "SettingsTabGeneralShowConfirmExitDialog": "Exibir diálogo de confirmação ao sair",
   "SettingsTabGeneralRememberWindowState": "Lembrar tamanho/posição da Janela",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Esconder o cursor do mouse:",
   "SettingsTabGeneralHideCursorNever": "Nunca",
   "SettingsTabGeneralHideCursorOnIdle": "Esconder o cursor quando ocioso",

--- a/src/Ryujinx/Assets/Locales/ru_RU.json
+++ b/src/Ryujinx/Assets/Locales/ru_RU.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Проверять наличие обновлений при запуске",
   "SettingsTabGeneralShowConfirmExitDialog": "Подтверждать выход из приложения",
   "SettingsTabGeneralRememberWindowState": "Запомнить размер/положение окна",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Скрывать курсор",
   "SettingsTabGeneralHideCursorNever": "Никогда",
   "SettingsTabGeneralHideCursorOnIdle": "В простое",

--- a/src/Ryujinx/Assets/Locales/th_TH.json
+++ b/src/Ryujinx/Assets/Locales/th_TH.json
@@ -100,6 +100,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "ตรวจหาการอัปเดตเมื่อเปิดโปรแกรม",
   "SettingsTabGeneralShowConfirmExitDialog": "แสดง \"ปุ่มยืนยันการออก\" เมื่อออกเกม",
   "SettingsTabGeneralRememberWindowState": "จดจำ ขนาดหน้าต่างแอพพลิเคชั่น/คำแหน่ง",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "ซ่อน เคอร์เซอร์:",
   "SettingsTabGeneralHideCursorNever": "ไม่ต้อง",
   "SettingsTabGeneralHideCursorOnIdle": "เมื่อไม่ได้ใช้งาน",

--- a/src/Ryujinx/Assets/Locales/tr_TR.json
+++ b/src/Ryujinx/Assets/Locales/tr_TR.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Her Açılışta Güncellemeleri Denetle",
   "SettingsTabGeneralShowConfirmExitDialog": "\"Çıkışı Onayla\" Diyaloğunu Göster",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "İşaretçiyi Gizle:",
   "SettingsTabGeneralHideCursorNever": "Hiçbir Zaman",
   "SettingsTabGeneralHideCursorOnIdle": "Hareketsiz Durumda",

--- a/src/Ryujinx/Assets/Locales/uk_UA.json
+++ b/src/Ryujinx/Assets/Locales/uk_UA.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "Перевіряти наявність оновлень під час запуску",
   "SettingsTabGeneralShowConfirmExitDialog": "Показати діалогове вікно «Підтвердити вихід».",
   "SettingsTabGeneralRememberWindowState": "Remember Window Size/Position",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "Сховати вказівник:",
   "SettingsTabGeneralHideCursorNever": "Ніколи",
   "SettingsTabGeneralHideCursorOnIdle": "Сховати у режимі очікування",

--- a/src/Ryujinx/Assets/Locales/zh_CN.json
+++ b/src/Ryujinx/Assets/Locales/zh_CN.json
@@ -100,6 +100,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "启动时检查更新",
   "SettingsTabGeneralShowConfirmExitDialog": "退出游戏时需要确认",
   "SettingsTabGeneralRememberWindowState": "记住窗口大小和位置",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "隐藏鼠标指针：",
   "SettingsTabGeneralHideCursorNever": "从不隐藏",
   "SettingsTabGeneralHideCursorOnIdle": "自动隐藏",

--- a/src/Ryujinx/Assets/Locales/zh_TW.json
+++ b/src/Ryujinx/Assets/Locales/zh_TW.json
@@ -97,6 +97,7 @@
   "SettingsTabGeneralCheckUpdatesOnLaunch": "啟動時檢查更新",
   "SettingsTabGeneralShowConfirmExitDialog": "顯示「確認結束」對話方塊",
   "SettingsTabGeneralRememberWindowState": "記住視窗大小/位置",
+  "SettingsTabGeneralShowTitleBar": "Show Title Bar (Requires restart)",
   "SettingsTabGeneralHideCursor": "隱藏滑鼠游標:",
   "SettingsTabGeneralHideCursorNever": "從不",
   "SettingsTabGeneralHideCursorOnIdle": "閒置時",

--- a/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
@@ -146,6 +146,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         public bool ShowConfirmExit { get; set; }
         public bool IgnoreApplet { get; set; }
         public bool RememberWindowState { get; set; }
+        public bool ShowTitleBar { get; set; }
         public int HideCursor { get; set; }
         public bool EnableDockedMode { get; set; }
         public bool EnableKeyboard { get; set; }
@@ -410,6 +411,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             ShowConfirmExit = config.ShowConfirmExit;
             IgnoreApplet = config.IgnoreApplet;
             RememberWindowState = config.RememberWindowState;
+            ShowTitleBar = config.ShowTitleBar;
             HideCursor = (int)config.HideCursor.Value;
 
             GameDirectories.Clear();
@@ -507,6 +509,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             config.ShowConfirmExit.Value = ShowConfirmExit;
             config.IgnoreApplet.Value = IgnoreApplet;
             config.RememberWindowState.Value = RememberWindowState;
+            config.ShowTitleBar.Value = ShowTitleBar;
             config.HideCursor.Value = (HideCursorMode)HideCursor;
 
             if (_gameDirectoryChanged)

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
@@ -13,7 +13,7 @@
         <viewModels:MainWindowViewModel />
     </Design.DataContext>
     <DockPanel HorizontalAlignment="Stretch">
-        <Border Padding="7, 0, 0, 0" VerticalAlignment="Center" HorizontalAlignment="Center">
+        <Border Name="RyuLogo" Padding="7, 0, 0, 0" VerticalAlignment="Center" HorizontalAlignment="Center">
             <Image 
                 ToolTip.Tip="{Binding Title}" 
                 Height="25" 

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml.cs
@@ -32,6 +32,8 @@ namespace Ryujinx.Ava.UI.Views.Main
         {
             InitializeComponent();
 
+            RyuLogo.IsVisible = (ConfigurationState.Instance.ShowTitleBar) ? false : true;
+
             ToggleFileTypesMenuItem.ItemsSource = GenerateToggleFileTypeItems();
             ChangeLanguageMenuItem.ItemsSource = GenerateLanguageMenuItems();
         }

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.Ava.UI.Views.Main
         {
             InitializeComponent();
 
-            RyuLogo.IsVisible = (ConfigurationState.Instance.ShowTitleBar) ? false : true;
+            RyuLogo.IsVisible = !ConfigurationState.Instance.ShowTitleBar;
 
             ToggleFileTypesMenuItem.ItemsSource = GenerateToggleFileTypeItems();
             ChangeLanguageMenuItem.ItemsSource = GenerateLanguageMenuItems();

--- a/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
@@ -39,7 +39,7 @@
                     <CheckBox IsChecked="{Binding RememberWindowState}">
                         <TextBlock Text="{locale:Locale SettingsTabGeneralRememberWindowState}" />
                     </CheckBox>
-                    <CheckBox IsChecked="{Binding ShowTitleBar}">
+                    <CheckBox IsChecked="{Binding ShowTitleBar}" Name="ShowTitleBarBox">
                         <TextBlock Text="{locale:Locale SettingsTabGeneralShowTitleBar}" />
                     </CheckBox>
                     <StackPanel Margin="0, 15, 0, 0" Orientation="Horizontal">

--- a/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml
@@ -39,6 +39,9 @@
                     <CheckBox IsChecked="{Binding RememberWindowState}">
                         <TextBlock Text="{locale:Locale SettingsTabGeneralRememberWindowState}" />
                     </CheckBox>
+                    <CheckBox IsChecked="{Binding ShowTitleBar}">
+                        <TextBlock Text="{locale:Locale SettingsTabGeneralShowTitleBar}" />
+                    </CheckBox>
                     <StackPanel Margin="0, 15, 0, 0" Orientation="Horizontal">
                         <TextBlock VerticalAlignment="Center"
                                    Text="{locale:Locale SettingsTabGeneralHideCursor}"

--- a/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Ava.UI.Views.Settings
         public SettingsUiView()
         {
             InitializeComponent();
-            ShowTitleBarBox.IsVisible = (OperatingSystem.IsWindows()) ? true : false;
+            ShowTitleBarBox.IsVisible = OperatingSystem.IsWindows();
         }
 
         private async void AddGameDirButton_OnClick(object sender, RoutedEventArgs e)

--- a/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml.cs
@@ -2,8 +2,8 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
-using Ryujinx.Ava.Common.Locale;
 using Ryujinx.Ava.UI.ViewModels;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,6 +17,7 @@ namespace Ryujinx.Ava.UI.Views.Settings
         public SettingsUiView()
         {
             InitializeComponent();
+            ShowTitleBarBox.IsVisible = (OperatingSystem.IsWindows()) ? true : false;
         }
 
         private async void AddGameDirButton_OnClick(object sender, RoutedEventArgs e)

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -82,7 +82,7 @@ namespace Ryujinx.Ava.UI.Windows
 
             ViewModel.Title = App.FormatTitle();
 
-            TitleBar.ExtendsContentIntoTitleBar = (ConfigurationState.Instance.ShowTitleBar) ? false : true;
+            TitleBar.ExtendsContentIntoTitleBar = !ConfigurationState.Instance.ShowTitleBar;
             TitleBar.TitleBarHitTestType = TitleBarHitTestType.Complex;
 
             // NOTE: Height of MenuBar and StatusBar is not usable here, since it would still be 0 at this point.

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -82,7 +82,7 @@ namespace Ryujinx.Ava.UI.Windows
 
             ViewModel.Title = App.FormatTitle();
 
-            TitleBar.ExtendsContentIntoTitleBar = true;
+            TitleBar.ExtendsContentIntoTitleBar = (ConfigurationState.Instance.ShowTitleBar) ? false : true;
             TitleBar.TitleBarHitTestType = TitleBarHitTestType.Complex;
 
             // NOTE: Height of MenuBar and StatusBar is not usable here, since it would still be 0 at this point.

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -83,7 +83,7 @@ namespace Ryujinx.Ava.UI.Windows
             ViewModel.Title = App.FormatTitle();
 
             TitleBar.ExtendsContentIntoTitleBar = !ConfigurationState.Instance.ShowTitleBar;
-            TitleBar.TitleBarHitTestType = TitleBarHitTestType.Complex;
+            TitleBar.TitleBarHitTestType = (ConfigurationState.Instance.ShowTitleBar) ? TitleBarHitTestType.Simple : TitleBarHitTestType.Complex;
 
             // NOTE: Height of MenuBar and StatusBar is not usable here, since it would still be 0 at this point.
             StatusBarHeight = StatusBarView.StatusBar.MinHeight;


### PR DESCRIPTION
Adds the option to show the title bar in the User Interface options. Ryujinx must be restarted in order for the change to take effect. 

https://github.com/user-attachments/assets/ae5724fe-7640-436d-942b-cb7277d0c496

This option defaults to false (unchecked) on Windows. Non-Windows OS's will not display this option and will permanently have the old title bar design.