### PR TITLE
Fix fullscreen when using 'Show Title Bar'

### DIFF
--- a/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
@@ -1767,6 +1767,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             if (WindowState is not WindowState.Normal)
             {
                 WindowState = WindowState.Normal;
+                Window.TitleBar.ExtendsContentIntoTitleBar = !ConfigurationState.Instance.ShowTitleBar;
 
                 if (IsGameRunning)
                 {
@@ -1776,6 +1777,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             else
             {
                 WindowState = WindowState.FullScreen;
+                Window.TitleBar.ExtendsContentIntoTitleBar = true;
 
                 if (IsGameRunning)
                 {

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
@@ -13,19 +13,20 @@
         <viewModels:MainWindowViewModel />
     </Design.DataContext>
     <DockPanel HorizontalAlignment="Stretch">
-        <Border Name="RyuLogo" Padding="7, 0, 0, 0" VerticalAlignment="Center" HorizontalAlignment="Center">
-            <Image 
-                ToolTip.Tip="{Binding Title}" 
-                Height="25" 
-                Width="25"
-                Source="resm:Ryujinx.UI.Common.Resources.Logo_Ryujinx.png?assembly=Ryujinx.UI.Common" />
-        </Border>
+        <Image
+            Name="RyuLogo"
+            Margin="7,0"
+            Height="25"
+            Width="25"
+            ToolTip.Tip="{Binding Title}"
+            Source="resm:Ryujinx.UI.Common.Resources.Logo_Ryujinx.png?assembly=Ryujinx.UI.Common" />
         <Menu
             Name="Menu"
             Height="35"
             Margin="0"
             HorizontalAlignment="Left"
             IsOpen="{Binding IsSubMenuOpen, Mode=OneWayToSource}">
+
             <Menu.ItemsPanel>
                 <ItemsPanelTemplate>
                     <DockPanel Margin="0" HorizontalAlignment="Stretch" />

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml
@@ -26,7 +26,6 @@
             Margin="0"
             HorizontalAlignment="Left"
             IsOpen="{Binding IsSubMenuOpen, Mode=OneWayToSource}">
-
             <Menu.ItemsPanel>
                 <ItemsPanelTemplate>
                     <DockPanel Margin="0" HorizontalAlignment="Stretch" />


### PR DESCRIPTION
This PR fixes an issue that caused part of the title bar would still be visible when using 'Show Title Bar' in fullscreen mode.

![IMG_20241031rrr_225936](https://github.com/user-attachments/assets/c4006833-9e1c-4fc8-adf7-96d0ac72ab44)
<sup>(Image courtesy of Fredy27 on Discord)<sup>

I have also simplified the code for the logo in the redesigned title bar.