### PR TITLE
fix index out of range check in GetCoefficientAtIndex

### DIFF
--- a/src/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
@@ -81,7 +81,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static short GetCoefficientAtIndex(ReadOnlySpan<short> coefficients, int index)
         {
-            if ((uint)index > (uint)coefficients.Length)
+            if ((uint)index >= (uint)coefficients.Length)
             {
                 Logger.Error?.Print(LogClass.AudioRenderer, $"Out of bound read for coefficient at index {index}");
 


### PR DESCRIPTION
This index out of range check would not hit if the index is equal to the length (which still makes it out of range), so I simply changed > to >=.
Should fix random crashes in titles like Super Mario Party Jamboree (this is where I encountered the bug).

This pull request fixes the following issue:
Fixes #17 