### PR TITLE
Update readme to better guide new users to the Releases tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Use the search function to see if a game has been tested already!
 To run this emulator, your PC must be equipped with at least 8GiB of RAM;
 failing to meet this requirement may result in a poor gameplay experience or unexpected crashes.
 
-## Latest build
+## Latest release
 
-These builds are compiled automatically for each commit on the master branch.
+Releases are compiled automatically for each commit on the master branch.
 While we strive to ensure optimal stability and performance prior to pushing an update, our automated builds **may be unstable or completely broken**.
 
 You can find the latest release [here](https://github.com/GreemDev/Ryujinx/releases/latest).
@@ -74,6 +74,7 @@ If you are planning to contribute or just want to learn more about this project 
 
 ## Building
 
+Building the project is for advanced users.
 If you wish to build the emulator yourself, follow these steps:
 
 ### Step 1


### PR DESCRIPTION
Changes the wording in the "Latest build" and "Building" sections to better guide new users.
"Latest build" has been changed to "Latest release" to make it more clear for new users that this is the easy option.
The "Building" section now tells the users that this is the advanced option.