### PR TITLE
Fix Vendor.cs error

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/Vendor.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Vendor.cs
@@ -92,7 +92,7 @@ namespace Ryujinx.Graphics.Vulkan
                 DriverId.MesaDozen => "Dozen",
                 DriverId.MesaNvk => "NVK",
                 DriverId.ImaginationOpenSourceMesa => "Imagination (Open)",
-                DriverId.MesaAgxv => "Honeykrisp",
+                DriverId.MesaHoneykrisp => "Honeykrisp",
                 _ => id.ToString(),
             };
         }


### PR DESCRIPTION
While updating Silk.net.vulkan, it show an error for not matching it name table, now rename it as match.