### PR TITLE
Add Dummy Applet to Replace NotImplementedException

### DIFF
--- a/src/Ryujinx.HLE/HOS/Applets/AppletManager.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/AppletManager.cs
@@ -1,4 +1,6 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Applets.Browser;
+using Ryujinx.HLE.HOS.Applets.Dummy;
 using Ryujinx.HLE.HOS.Applets.Error;
 using Ryujinx.HLE.HOS.Services.Am.AppletAE;
 using System;
@@ -26,9 +28,13 @@ namespace Ryujinx.HLE.HOS.Applets
                     return new BrowserApplet(system);
                 case AppletId.LibAppletOff:
                     return new BrowserApplet(system);
+                case AppletId.MiiEdit:
+                    Logger.Warning?.Print(LogClass.Application, $"Please use the MiiEdit inside File/Open Applet");
+                    return new DummyApplet(system);
             }
 
-            throw new NotImplementedException($"{applet} applet is not implemented.");
+            Logger.Warning?.Print(LogClass.Application, $"Applet {applet} not implemented!");
+            return new DummyApplet(system);
         }
     }
 }

--- a/src/Ryujinx.HLE/HOS/Applets/Dummy/DummyApplet.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/Dummy/DummyApplet.cs
@@ -1,0 +1,43 @@
+using Ryujinx.Common.Logging;
+using Ryujinx.Common.Memory;
+using Ryujinx.HLE.HOS.Applets;
+using Ryujinx.HLE.HOS.Services.Am.AppletAE;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+namespace Ryujinx.HLE.HOS.Applets.Dummy
+{
+    internal class DummyApplet : IApplet
+    {
+        private readonly Horizon _system;
+        private AppletSession _normalSession;
+        public event EventHandler AppletStateChanged;
+        public DummyApplet(Horizon system)
+        {
+            _system = system;
+        }
+        public ResultCode Start(AppletSession normalSession, AppletSession interactiveSession)
+        {
+            _normalSession = normalSession;
+            _normalSession.Push(BuildResponse());
+            AppletStateChanged?.Invoke(this, null);
+            _system.ReturnFocus();
+            return ResultCode.Success;
+        }
+        private static T ReadStruct<T>(byte[] data) where T : struct
+        {
+            return MemoryMarshal.Read<T>(data.AsSpan());
+        }
+        private static byte[] BuildResponse()
+        {
+            using MemoryStream stream = MemoryStreamManager.Shared.GetStream();
+            using BinaryWriter writer = new(stream);
+            writer.Write((ulong)ResultCode.Success);
+            return stream.ToArray();
+        }
+        public ResultCode GetResult()
+        {
+            return ResultCode.Success;
+        }
+    }
+}


### PR DESCRIPTION
Currently, in Ryujinx, if an app attempts to open an unimplemented applet, it crashes. This change adds a dummy applet to send a dummy response instead of crashing and logs the applet.