### PR TITLE
Adds the ability to read a amiibo's nickname from the VirtualAmiiboFile

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
@@ -688,7 +688,8 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                         {
                             RegisterInfo registerInfo = VirtualAmiibo.GetRegisterInfo(
                                 context.Device.System.TickSource,
-                                context.Device.System.NfpDevices[i].AmiiboId);
+                                context.Device.System.NfpDevices[i].AmiiboId,
+                                context.Device.System.AccountManager.LastOpenedUser.Name);
 
                             context.Memory.Write(outputPosition, registerInfo);
 

--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
@@ -688,8 +688,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                         {
                             RegisterInfo registerInfo = VirtualAmiibo.GetRegisterInfo(
                                 context.Device.System.TickSource,
-                                context.Device.System.NfpDevices[i].AmiiboId,
-                                context.Device.System.AccountManager.LastOpenedUser.Name);
+                                context.Device.System.NfpDevices[i].AmiiboId);
 
                             context.Memory.Write(outputPosition, registerInfo);
 

--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/VirtualAmiiboFile.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/VirtualAmiiboFile.cs
@@ -8,6 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
         public uint FileVersion { get; set; }
         public byte[] TagUuid { get; set; }
         public string AmiiboId { get; set; }
+        public string NickName { get; set; }
         public DateTime FirstWriteDate { get; set; }
         public DateTime LastWriteDate { get; set; }
         public ushort WriteCounter { get; set; }

--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -64,7 +64,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             };
         }
 
-        public static RegisterInfo GetRegisterInfo(ITickSource tickSource, string amiiboId)
+        public static RegisterInfo GetRegisterInfo(ITickSource tickSource, string amiiboId, string userName)
         {
             VirtualAmiiboFile amiiboFile = LoadAmiiboFile(amiiboId);
             string nickname = "Ryujinx";
@@ -77,7 +77,8 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             charInfo.SetFromStoreData(StoreData.BuildDefault(utilityImpl, 0));
 
-            charInfo.Nickname = Nickname.FromString(nickname);
+            // This is the player's name
+            charInfo.Nickname = Nickname.FromString(userName);
 
             RegisterInfo registerInfo = new()
             {
@@ -89,7 +90,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 Reserved1 = new Array64<byte>(),
                 Reserved2 = new Array58<byte>(),
             };
-            //"Ryujinx"u8.CopyTo(registerInfo.Nickname.AsSpan());
+            // This is the amiibo's name
             byte[] nicknameBytes = System.Text.Encoding.UTF8.GetBytes(nickname);
             nicknameBytes.CopyTo(registerInfo.Nickname.AsSpan());
 

--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -64,10 +64,14 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             };
         }
 
-        public static RegisterInfo GetRegisterInfo(ITickSource tickSource, string amiiboId, string nickname)
+        public static RegisterInfo GetRegisterInfo(ITickSource tickSource, string amiiboId)
         {
             VirtualAmiiboFile amiiboFile = LoadAmiiboFile(amiiboId);
-
+            string nickname = "Ryujinx";
+            if (amiiboFile.NickName != null)
+            {
+                nickname = amiiboFile.NickName;
+            }
             UtilityImpl utilityImpl = new(tickSource);
             CharInfo charInfo = new();
 
@@ -85,7 +89,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 Reserved1 = new Array64<byte>(),
                 Reserved2 = new Array58<byte>(),
             };
-            "Ryujinx"u8.CopyTo(registerInfo.Nickname.AsSpan());
+            //"Ryujinx"u8.CopyTo(registerInfo.Nickname.AsSpan());
+            byte[] nicknameBytes = System.Text.Encoding.UTF8.GetBytes(nickname);
+            nicknameBytes.CopyTo(registerInfo.Nickname.AsSpan());
 
             return registerInfo;
         }

--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -67,11 +67,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         public static RegisterInfo GetRegisterInfo(ITickSource tickSource, string amiiboId, string userName)
         {
             VirtualAmiiboFile amiiboFile = LoadAmiiboFile(amiiboId);
-            string nickname = "Ryujinx";
-            if (amiiboFile.NickName != null)
-            {
-                nickname = amiiboFile.NickName;
-            }
+            string nickname = amiiboFile.NickName ?? "Ryujinx";
             UtilityImpl utilityImpl = new(tickSource);
             CharInfo charInfo = new();
 


### PR DESCRIPTION
This feature adds a way to change the Amiibo's nickname inside Smash and other places where it's used, so it’s not always "Ryujinx." However, I did not add a GUI or create the Cabinet applet that would allow users to change this. So you will have to go to system/amiibo and find your amiibo id to change it.