### PR TITLE
Fix issue with Logger.Trace

### DIFF
--- a/src/Ryujinx.UI.Common/Configuration/LoggerModule.cs
+++ b/src/Ryujinx.UI.Common/Configuration/LoggerModule.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.UI.Common.Configuration
             ConfigurationState.Instance.Logger.EnableError.Event += 
                 (_, e) => Logger.SetEnable(LogLevel.Error, e.NewValue);
             ConfigurationState.Instance.Logger.EnableTrace.Event += 
-                (_, e) => Logger.SetEnable(LogLevel.Error, e.NewValue);
+                (_, e) => Logger.SetEnable(LogLevel.Trace, e.NewValue);
             ConfigurationState.Instance.Logger.EnableGuest.Event += 
                 (_, e) => Logger.SetEnable(LogLevel.Guest, e.NewValue);
             ConfigurationState.Instance.Logger.EnableFsAccessLog.Event +=


### PR DESCRIPTION
There was a mistake in a recent commit that caused "Trace" logging to always be enabled, no matter the configuration value.
This quickly generates large log files that might be unwanted.