### PR TITLE
Fix divide by zero when recovering from missed draw (Vulkan), authored by EmulationEnjoyer

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
@@ -55,8 +55,10 @@ namespace Ryujinx.Graphics.Vulkan
             if (_handle != BufferHandle.Null)
             {
                 // May need to restride the vertex buffer.
-
-                if (gd.NeedsVertexBufferAlignment(AttributeScalarAlignment, out int alignment) && (_stride % alignment) != 0)
+                //
+                // Fix divide by zero when recovering from missed draw (Oct. 16 2024)
+                // (fixes crash in 'Baldo: The Guardian Owls' opening cutscene)
+                if (gd.NeedsVertexBufferAlignment(AttributeScalarAlignment, out int alignment) && alignment != 0 && (_stride % alignment) != 0)
                 {
                     autoBuffer = gd.BufferManager.GetAlignedVertexBuffer(cbs, _handle, _offset, _size, _stride, alignment);
 


### PR DESCRIPTION
Adds the fix for the crash in the opening cutscene of Baldo: The Sacred Owls when using Vulkan, from ryujinx-mirror. The original discussion about the fix can be found [here.](https://github.com/ryujinx-mirror/ryujinx/pull/52)

It's up to you if you want to merge this, it's one of the very few improvements that ryujinx-mirror got that hasn't made it into your fork yet. My opinion is that without a graphics expert on board, we can't know the real cause of this divide-by-zero issue and will have to make do with this patch to fix it. And I think we will have to do this many times in the future for other games that suffer crashes at the moment as well, at least going by current discussions in the #development section of the discord. 

I did not come up with this fix, all credit goes to [EmulationEnjoyer](https://github.com/EmulationEnjoyer) for putting Ryujinx through a debugger and discovering the cause of the crash. 