### PR TITLE
Implement IAllSystemAppletProxiesService: 350 (OpenSystemApplicationProxy)

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
@@ -28,6 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
         }
 
         [CommandCmif(350)]
+        // OpenSystemApplicationProxy(u64, pid, handle<copy>) -> object<nn::am::service::IApplicationProxy>
         public ResultCode OpenSystemApplicationProxy(ServiceCtx context)
         {
             MakeObject(context, new IApplicationProxy(context.Request.HandleDesc.PId));

--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
@@ -1,4 +1,5 @@
 using Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService;
+using Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService;
 
 namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
 {
@@ -22,6 +23,14 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
         public ResultCode OpenLibraryAppletProxy(ServiceCtx context)
         {
             MakeObject(context, new ILibraryAppletProxy(context.Request.HandleDesc.PId));
+
+            return ResultCode.Success;
+        }
+
+        [CommandCmif(350)]
+        public ResultCode OpenSystemApplicationProxy(ServiceCtx context)
+        {
+            MakeObject(context, new IApplicationProxy(context.Request.HandleDesc.PId));
 
             return ResultCode.Success;
         }


### PR DESCRIPTION
Implements IAllSystemAppletProxiesService: 350 (OpenSystemApplicationProxy)

This fixes a crash that occurs when launching an NSP forwarder generated by Nro2Nsp.