### PR TITLE
Fix window sizing when "Show Title Bar" is enabled

### DIFF
--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml.cs
@@ -184,24 +184,24 @@ namespace Ryujinx.Ava.UI.Views.Main
             if (sender is not MenuItem { Tag: string resolution })
                 return;
 
-            (int resolution_width, int resolution_height) = resolution.Split(' ', 2)
+            (int resolutionWidth, int resolutionHeight) = resolution.Split(' ', 2)
                 .Into(parts => 
                     (int.Parse(parts[0]), int.Parse(parts[1]))
                 );
 
             // Correctly size window when 'TitleBar' is enabled (Nov. 14, 2024)
-            double bars_height = ((Window.StatusBarHeight + Window.MenuBarHeight) +
+            double barsHeight = ((Window.StatusBarHeight + Window.MenuBarHeight) +
                 (ConfigurationState.Instance.ShowTitleBar ? (int)Window.TitleBar.Height : 0));
 
-            double window_width_scaled = (resolution_width * Program.WindowScaleFactor);
-            double window_height_scaled = ((resolution_height + bars_height) * Program.WindowScaleFactor);
+            double windowWidthScaled = (resolutionWidth * Program.WindowScaleFactor);
+            double windowHeightScaled = ((resolutionHeight + barsHeight) * Program.WindowScaleFactor);
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 
                 ViewModel.WindowState = WindowState.Normal;
 
-                Window.Arrange(new Rect(Window.Position.X, Window.Position.Y, window_width_scaled, window_height_scaled));
+                Window.Arrange(new Rect(Window.Position.X, Window.Position.Y, windowWidthScaled, windowHeightScaled));
             });
         }
 

--- a/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Main/MainMenuBarView.axaml.cs
@@ -184,18 +184,24 @@ namespace Ryujinx.Ava.UI.Views.Main
             if (sender is not MenuItem { Tag: string resolution })
                 return;
 
-            (int width, int height) = resolution.Split(' ', 2)
+            (int resolution_width, int resolution_height) = resolution.Split(' ', 2)
                 .Into(parts => 
                     (int.Parse(parts[0]), int.Parse(parts[1]))
                 );
 
+            // Correctly size window when 'TitleBar' is enabled (Nov. 14, 2024)
+            double bars_height = ((Window.StatusBarHeight + Window.MenuBarHeight) +
+                (ConfigurationState.Instance.ShowTitleBar ? (int)Window.TitleBar.Height : 0));
+
+            double window_width_scaled = (resolution_width * Program.WindowScaleFactor);
+            double window_height_scaled = ((resolution_height + bars_height) * Program.WindowScaleFactor);
+
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
+                
                 ViewModel.WindowState = WindowState.Normal;
 
-                height += (int)Window.StatusBarHeight + (int)Window.MenuBarHeight;
-
-                Window.Arrange(new Rect(Window.Position.X, Window.Position.Y, width, height));
+                Window.Arrange(new Rect(Window.Position.X, Window.Position.Y, window_width_scaled, window_height_scaled));
             });
         }
 

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -65,6 +65,9 @@ namespace Ryujinx.Ava.UI.Windows
         public static bool ShowKeyErrorOnLoad { get; set; }
         public ApplicationLibrary ApplicationLibrary { get; set; }
 
+        // Correctly size window when 'TitleBar' is enabled (Nov. 14, 2024)
+        public readonly double TitleBarHeight;
+
         public readonly double StatusBarHeight;
         public readonly double MenuBarHeight;
 
@@ -85,12 +88,12 @@ namespace Ryujinx.Ava.UI.Windows
             TitleBar.ExtendsContentIntoTitleBar = !ConfigurationState.Instance.ShowTitleBar;
             TitleBar.TitleBarHitTestType = (ConfigurationState.Instance.ShowTitleBar) ? TitleBarHitTestType.Simple : TitleBarHitTestType.Complex;
 
+            // Correctly size window when 'TitleBar' is enabled (Nov. 14, 2024)
+            TitleBarHeight = (ConfigurationState.Instance.ShowTitleBar ? TitleBar.Height : 0);
+
             // NOTE: Height of MenuBar and StatusBar is not usable here, since it would still be 0 at this point.
             StatusBarHeight = StatusBarView.StatusBar.MinHeight;
             MenuBarHeight = MenuBar.MinHeight;
-            double barHeight = MenuBarHeight + StatusBarHeight;
-            Height = ((Height - barHeight) / Program.WindowScaleFactor) + barHeight;
-            Width /= Program.WindowScaleFactor;
 
             SetWindowSizePosition();
 
@@ -406,7 +409,8 @@ namespace Ryujinx.Ava.UI.Windows
         {
             if (!ConfigurationState.Instance.RememberWindowState)
             {
-                ViewModel.WindowHeight = (720 + StatusBarHeight + MenuBarHeight) * Program.WindowScaleFactor;
+                // Correctly size window when 'TitleBar' is enabled (Nov. 14, 2024)
+                ViewModel.WindowHeight = (720 + StatusBarHeight + MenuBarHeight + TitleBarHeight) * Program.WindowScaleFactor;
                 ViewModel.WindowWidth = 1280 * Program.WindowScaleFactor;
 
                 WindowState = WindowState.Normal;

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -445,8 +445,10 @@ namespace Ryujinx.Ava.UI.Windows
             // Only save rectangle properties if the window is not in a maximized state.
             if (WindowState != WindowState.Maximized)
             {
-                ConfigurationState.Instance.UI.WindowStartup.WindowSizeHeight.Value = (int)Height;
-                ConfigurationState.Instance.UI.WindowStartup.WindowSizeWidth.Value = (int)Width;
+                // Since scaling is being applied to the loaded settings from disk (see SetWindowSizePosition() above), scaling should be removed from width/height before saving out to disk
+                // as well - otherwise anyone not using a 1.0 scale factor their window will increase in size with every subsequent launch of the program when scaling is applied (Nov. 14, 2024)
+                ConfigurationState.Instance.UI.WindowStartup.WindowSizeHeight.Value = (int)(Height / Program.WindowScaleFactor);
+                ConfigurationState.Instance.UI.WindowStartup.WindowSizeWidth.Value = (int)(Width / Program.WindowScaleFactor);
 
                 ConfigurationState.Instance.UI.WindowStartup.WindowPositionX.Value = Position.X;
                 ConfigurationState.Instance.UI.WindowStartup.WindowPositionY.Value = Position.Y;


### PR DESCRIPTION
Fixes a bug that causes the main window to not size properly when the TitleBar is enabled (i.e.: when the TitleBar and MenuStrip are separate entities). Corrects the size for main window startup and when a user clicks a "View > Window Size > *Resolution Here*" MenuStripItem 

Prior to this fix if a user selects 720p/1080p and "Show Title Bar" is enabled, the window would be sized smaller than intended and display black bars on the sides of the render area

![window_sizing_fix](https://github.com/user-attachments/assets/9835c9ed-c5ee-4daf-8364-f2b4576f533e)

Fixes a window height calculation issue