### PR TITLE
Add `XCITrimmerTrim` and `XCITrimmerUntrim` Locales

### DIFF
--- a/src/Ryujinx/Assets/Locales/ar_SA.json
+++ b/src/Ryujinx/Assets/Locales/ar_SA.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "إدارة المحتوى القابل للتنزيل لـ {0} ({1})",
   "ModWindowTitle": "إدارة التعديلات لـ {0} ({1})",
   "UpdateWindowTitle": "مدير تحديث العنوان",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "الغش متوفر لـ {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/de_DE.json
+++ b/src/Ryujinx/Assets/Locales/de_DE.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "Spiel-DLC verwalten",
   "ModWindowTitle": "Manage Mods for {0} ({1})",
   "UpdateWindowTitle": "Spiel-Updates verwalten",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "Cheats verfügbar für {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/el_GR.json
+++ b/src/Ryujinx/Assets/Locales/el_GR.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "Downloadable Content Manager",
   "ModWindowTitle": "Manage Mods for {0} ({1})",
   "UpdateWindowTitle": "Διαχειριστής Ενημερώσεων Τίτλου",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "Διαθέσιμα Cheats για {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -767,6 +767,8 @@
   "XCITrimmerDeselectDisplayed": "Deselect Shown",
   "XCITrimmerSortName": "Title",
   "XCITrimmerSortSaved": "Space Savings",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "Cheats Available for {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/es_ES.json
+++ b/src/Ryujinx/Assets/Locales/es_ES.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "Administrar contenido descargable",
   "ModWindowTitle": "Administrar Mods para {0} ({1})",
   "UpdateWindowTitle": "Administrar actualizaciones",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} nueva(s) actualización(es) agregada(s)",
   "UpdateWindowBundledContentNotice": "Las actualizaciones agrupadas no pueden ser eliminadas, solamente deshabilitadas.",
   "CheatWindowHeading": "Cheats disponibles para {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/he_IL.json
+++ b/src/Ryujinx/Assets/Locales/he_IL.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "נהל הרחבות משחק עבור {0} ({1})",
   "ModWindowTitle": "Manage Mods for {0} ({1})",
   "UpdateWindowTitle": "נהל עדכוני משחקים",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "צ'יטים זמינים עבור {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/it_IT.json
+++ b/src/Ryujinx/Assets/Locales/it_IT.json
@@ -767,6 +767,8 @@
   "XCITrimmerDeselectDisplayed": "Deselziona Visualizzati",
   "XCITrimmerSortName": "Titolo",
   "XCITrimmerSortSaved": "Salvataggio Spazio",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} aggiornamento/i aggiunto/i",
   "UpdateWindowBundledContentNotice": "Gli aggiornamenti inclusi non possono essere eliminati, ma solo disattivati",
   "CheatWindowHeading": "Trucchi disponibili per {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/ja_JP.json
+++ b/src/Ryujinx/Assets/Locales/ja_JP.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "DLC 管理",
   "ModWindowTitle": "Manage Mods for {0} ({1})",
   "UpdateWindowTitle": "アップデート管理",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "利用可能なチート {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/ko_KR.json
+++ b/src/Ryujinx/Assets/Locales/ko_KR.json
@@ -767,6 +767,8 @@
   "XCITrimmerDeselectDisplayed": "표시됨 선택 취소",
   "XCITrimmerSortName": "타이틀",
   "XCITrimmerSortSaved": "공간 절약s",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0}개의 새 업데이트가 추가됨",
   "UpdateWindowBundledContentNotice": "번들 업데이트는 제거할 수 없으며, 비활성화만 가능합니다.",
   "CheatWindowHeading": "{0} [{1}]에 사용 가능한 치트",

--- a/src/Ryujinx/Assets/Locales/pl_PL.json
+++ b/src/Ryujinx/Assets/Locales/pl_PL.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "Menedżer Zawartości do Pobrania",
   "ModWindowTitle": "Zarządzaj modami dla {0} ({1})",
   "UpdateWindowTitle": "Menedżer Aktualizacji Tytułu",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "Kody Dostępne dla {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/pt_BR.json
+++ b/src/Ryujinx/Assets/Locales/pt_BR.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "Gerenciador de DLC",
   "ModWindowTitle": "Gerenciar Mods para {0} ({1})",
   "UpdateWindowTitle": "Gerenciador de atualizações",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} nova(s) atualização(ões) adicionada(s)",
   "UpdateWindowBundledContentNotice": "Atualizações incorporadas não podem ser removidas, apenas desativadas.",
   "CheatWindowHeading": "Cheats disponíveis para {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/ru_RU.json
+++ b/src/Ryujinx/Assets/Locales/ru_RU.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "Управление DLC для {0} ({1})",
   "ModWindowTitle": "Управление модами для {0} ({1})",
   "UpdateWindowTitle": "Менеджер обновлений игр",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "Доступные читы для {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/th_TH.json
+++ b/src/Ryujinx/Assets/Locales/th_TH.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "จัดการ DLC ที่ดาวน์โหลดได้สำหรับ {0} ({1})",
   "ModWindowTitle": "จัดการม็อดที่ดาวน์โหลดได้สำหรับ {0} ({1})",
   "UpdateWindowTitle": "จัดการอัปเดตหัวข้อ",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} อัพเดตที่เพิ่มมาใหม่",
   "UpdateWindowBundledContentNotice": "แพ็คที่อัพเดตมาไม่สามารถลบทิ้งได้ สามารถปิดใช้งานได้เท่านั้น",
   "CheatWindowHeading": "สูตรโกงมีให้สำหรับ {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/tr_TR.json
+++ b/src/Ryujinx/Assets/Locales/tr_TR.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "Oyun DLC'lerini Yönet",
   "ModWindowTitle": "Manage Mods for {0} ({1})",
   "UpdateWindowTitle": "Oyun Güncellemelerini Yönet",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "{0} için Hile mevcut [{1}]",

--- a/src/Ryujinx/Assets/Locales/uk_UA.json
+++ b/src/Ryujinx/Assets/Locales/uk_UA.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "Менеджер вмісту для завантаження",
   "ModWindowTitle": "Керувати модами для {0} ({1})",
   "UpdateWindowTitle": "Менеджер оновлення назв",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} new update(s) added",
   "UpdateWindowBundledContentNotice": "Bundled updates cannot be removed, only disabled.",
   "CheatWindowHeading": "Коди доступні для {0} [{1}]",

--- a/src/Ryujinx/Assets/Locales/zh_CN.json
+++ b/src/Ryujinx/Assets/Locales/zh_CN.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "管理 {0} ({1}) 的 DLC",
   "ModWindowTitle": "管理 {0} ({1}) 的 MOD",
   "UpdateWindowTitle": "游戏更新管理器",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "{0} 个更新被添加",
   "UpdateWindowBundledContentNotice": "捆绑的更新无法被移除，只可被禁用。",
   "CheatWindowHeading": "适用于 {0} [{1}] 的金手指",

--- a/src/Ryujinx/Assets/Locales/zh_TW.json
+++ b/src/Ryujinx/Assets/Locales/zh_TW.json
@@ -728,6 +728,8 @@
   "DlcWindowTitle": "管理 {0} 的可下載內容 ({1})",
   "ModWindowTitle": "管理 {0} 的模組 ({1})",
   "UpdateWindowTitle": "遊戲更新管理員",
+  "XCITrimmerTrim": "Trim",
+  "XCITrimmerUntrim": "Untrim",
   "UpdateWindowUpdateAddedMessage": "已加入 {0} 個遊戲更新",
   "UpdateWindowBundledContentNotice": "附帶的遊戲更新只能被停用而無法被刪除。",
   "CheatWindowHeading": "可用於 {0} [{1}] 的密技",

--- a/src/Ryujinx/UI/Windows/XCITrimmerWindow.axaml
+++ b/src/Ryujinx/UI/Windows/XCITrimmerWindow.axaml
@@ -296,7 +296,7 @@
                         Margin="5"
                         Click="Trim"
                         IsEnabled="{Binding CanTrim}">
-                        <TextBlock Text="Trim" />
+                        <TextBlock Text="{ext:Locale XCITrimmerTrim}" />
                     </Button>
                     <Button
                         Name="UntrimButton"
@@ -304,7 +304,7 @@
                         Margin="5"
                         Click="Untrim"
                         IsEnabled="{Binding CanUntrim}">
-                        <TextBlock Text="Untrim" />
+                        <TextBlock Text="{ext:Locale XCITrimmerUntrim}" />
                     </Button>
                 </StackPanel>
                 <StackPanel


### PR DESCRIPTION
This adds the ability to localize the "Trim" and "Untrim" buttons in the XCI Trimmer

If you're wondering where the locales for fr_FR, they're coming in another PR/commit