### PR TITLE
v1.2.76

### DIFF
--- a/src/Ryujinx.UI.Common/Helper/FileAssociationHelper.cs
+++ b/src/Ryujinx.UI.Common/Helper/FileAssociationHelper.cs
@@ -101,13 +101,13 @@ namespace Ryujinx.UI.Common.Helper
             {
                 RegistryKey key = Registry.CurrentUser.OpenSubKey(@$"Software\Classes\{ext}");
 
-                if (key is null)
+                var openCmd = key?.OpenSubKey(@"shell\open\command");
+                
+                if (openCmd is null)
                 {
                     return false;
                 }
-
-                var openCmd = key.OpenSubKey(@"shell\open\command");
-
+                
                 string keyValue = (string)openCmd.GetValue(string.Empty);
 
                 return keyValue is not null && (keyValue.Contains("Ryujinx") || keyValue.Contains(AppDomain.CurrentDomain.FriendlyName));


### PR DESCRIPTION
Fixes a null ref in FileAssociationHelper, likely due to a missing registry entry. Not too sure, but it works.