### PR TITLE
ARMeilleure: Implement TPIDR2_EL0

### DIFF
--- a/src/ARMeilleure/Instructions/InstEmitSystem.cs
+++ b/src/ARMeilleure/Instructions/InstEmitSystem.cs
@@ -49,6 +49,9 @@ namespace ARMeilleure.Instructions
                 case 0b11_011_1101_0000_011:
                     EmitGetTpidrroEl0(context);
                     return;
+                case 0b11_011_1101_0000_101:
+                    EmitGetTpidr2El0(context);
+                    return;
                 case 0b11_011_1110_0000_000:
                     info = typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetCntfrqEl0));
                     break;
@@ -83,6 +86,9 @@ namespace ARMeilleure.Instructions
                     return;
                 case 0b11_011_1101_0000_010:
                     EmitSetTpidrEl0(context);
+                    return;
+                case 0b11_011_1101_0000_101:
+                    EmitGetTpidr2El0(context);
                     return;
 
                 default:
@@ -209,6 +215,17 @@ namespace ARMeilleure.Instructions
             Operand nativeContext = context.LoadArgument(OperandType.I64, 0);
 
             Operand result = context.Load(OperandType.I64, context.Add(nativeContext, Const((ulong)NativeContext.GetTpidrroEl0Offset())));
+
+            SetIntOrZR(context, op.Rt, result);
+        }
+
+        private static void EmitGetTpidr2El0(ArmEmitterContext context)
+        {
+            OpCodeSystem op = (OpCodeSystem)context.CurrOp;
+
+            Operand nativeContext = context.LoadArgument(OperandType.I64, 0);
+
+            Operand result = context.Load(OperandType.I64, context.Add(nativeContext, Const((ulong)NativeContext.GetTpidr2El0Offset())));
 
             SetIntOrZR(context, op.Rt, result);
         }

--- a/src/ARMeilleure/State/NativeContext.cs
+++ b/src/ARMeilleure/State/NativeContext.cs
@@ -21,6 +21,7 @@ namespace ARMeilleure.State
             public ulong ExclusiveValueLow;
             public ulong ExclusiveValueHigh;
             public int Running;
+            public long Tpidr2El0;
         }
 
         private static NativeCtxStorage _dummyStorage = new();
@@ -176,6 +177,9 @@ namespace ARMeilleure.State
         public long GetTpidrroEl0() => GetStorage().TpidrroEl0;
         public void SetTpidrroEl0(long value) => GetStorage().TpidrroEl0 = value;
 
+        public long GetTpidr2El0() => GetStorage().Tpidr2El0;
+        public void SetTpidr2El0(long value) => GetStorage().Tpidr2El0 = value;
+
         public int GetCounter() => GetStorage().Counter;
         public void SetCounter(int value) => GetStorage().Counter = value;
 
@@ -230,6 +234,11 @@ namespace ARMeilleure.State
         public static int GetTpidrroEl0Offset()
         {
             return StorageOffset(ref _dummyStorage, ref _dummyStorage.TpidrroEl0);
+        }
+
+        public static int GetTpidr2El0Offset()
+        {
+            return StorageOffset(ref _dummyStorage, ref _dummyStorage.Tpidr2El0);
         }
 
         public static int GetCounterOffset()


### PR DESCRIPTION
This is an implementation of the TPIDR2_EL0 register. There may be more potential use-cases for this register not included in this PR, but this implements the use-case seen in SuperTuxKart.

This fixes a crash that occurs in the initial loading screen of [the latest SuperTuxKart preview build](https://github.com/supertuxkart/stk-code/releases/download/preview/SuperTuxKart-git20241112-switch.zip).

![image](https://github.com/user-attachments/assets/629be3dc-9c8c-49ab-95d9-12f1738c6de7)
