### PR TITLE
Add `documentation` and `ldn` labels to `labeler.yml`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,9 +35,9 @@ infra:
   - any-glob-to-any-file: ['.github/**', 'distribution/**', 'Directory.Packages.props']
 
 documentation:
-  - changed-files:
-      - any-glob-to-any-file: 'docs/**'
+- changed-files:
+  - any-glob-to-any-file: 'docs/**'
 
 ldn:
-  - changed-files:
-      - any-glob-to-any-file: 'src/Ryujinx.HLE/HOS/Services/Ldn/**'
+- changed-files:
+  - any-glob-to-any-file: 'src/Ryujinx.HLE/HOS/Services/Ldn/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,3 +33,11 @@ kernel:
 infra:
 - changed-files:
   - any-glob-to-any-file: ['.github/**', 'distribution/**', 'Directory.Packages.props']
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: 'docs/**'
+
+ldn:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Ryujinx.HLE/HOS/Services/Ldn/**'


### PR DESCRIPTION
This should make it so that any changes made to ldn and documentation related files should be auto-labeled