### PR TITLE
Fix window decorations being too wide

### DIFF
--- a/src/Ryujinx/Assets/Styles/Styles.xaml
+++ b/src/Ryujinx/Assets/Styles/Styles.xaml
@@ -1,7 +1,8 @@
 ﻿<Styles
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia">
+    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+    xmlns:windowing="clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia">
     <Design.PreviewWith>
         <Border Height="2000"
                 Padding="20">
@@ -231,7 +232,7 @@
         <Setter Property="BorderBrush"
                 Value="{DynamicResource HighlightBrush}" />
     </Style>
-    <Style Selector="Button">
+    <Style Selector="Button:not(windowing|MinMaxCloseControl Button)">
         <Setter Property="MinWidth"
                 Value="80" />
     </Style>


### PR DESCRIPTION
This PR fixes the window decorations being too wide after the switch to AppWindow.

After some investigating I found out that the MinWidth button style that was applied globally affected the custom implementation of the window decorations created by the FluentAvalonia library.

I therefore excluded these buttons from the style which fixes the issue while not affecting other parts of the UI where this MinWidth style may have been intended.

As a bonus, this also seems to fix the missing window tiling selector (or whatever it is called) on Windows 11 which should appear when hovering over the minimize/maximize button. For me, this was (almost always) broken until I applied this fix.

As I'm no expert regarding Avalonia, please feel free to let me know if you see any issues with this approach! 👍🏻
Additionally, I could only test this change on a Windows (11) machine, so if anyone else could confirm that this does not break the window decorations on macOS or Linux, that would be great!

Fixes #19 