### PR TITLE
ARMeilleure: Allow TPIDR2_EL0 to be set properly

### DIFF
--- a/src/ARMeilleure/Instructions/InstEmitSystem.cs
+++ b/src/ARMeilleure/Instructions/InstEmitSystem.cs
@@ -88,7 +88,7 @@ namespace ARMeilleure.Instructions
                     EmitSetTpidrEl0(context);
                     return;
                 case 0b11_011_1101_0000_101:
-                    EmitGetTpidr2El0(context);
+                    EmitSetTpidr2El0(context);
                     return;
 
                 default:
@@ -290,6 +290,17 @@ namespace ARMeilleure.Instructions
             Operand nativeContext = context.LoadArgument(OperandType.I64, 0);
 
             context.Store(context.Add(nativeContext, Const((ulong)NativeContext.GetTpidrEl0Offset())), value);
+        }
+
+        private static void EmitSetTpidr2El0(ArmEmitterContext context)
+        {
+            OpCodeSystem op = (OpCodeSystem)context.CurrOp;
+
+            Operand value = GetIntOrZR(context, op.Rt);
+
+            Operand nativeContext = context.LoadArgument(OperandType.I64, 0);
+
+            context.Store(context.Add(nativeContext, Const((ulong)NativeContext.GetTpidr2El0Offset())), value);
         }
     }
 }


### PR DESCRIPTION
This fixes an oversight I made in #280 where instead of setting the value of TPIDR2_EL0, the value would be retrieved instead. I believe we were able to get away with this because SuperTuxKart only sets the value to 0.