### PR TITLE
Stub Ldn.Lp2p.ISfService: 776 (DestroyGroup)

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Ldn/Lp2p/ISfService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/Lp2p/ISfService.cs
@@ -24,6 +24,15 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.Lp2p
             return ResultCode.Success;
         }
 
+        [CommandCmif(776)]
+        // DestroyGroup()
+        public ResultCode DestroyGroup(ServiceCtx context)
+        {
+            Logger.Stub?.PrintStub(LogClass.ServiceLdn);
+
+            return ResultCode.Success;
+        }
+
         [CommandCmif(1536)]
         // SendToOtherGroup(nn::lp2p::MacAddress, nn::lp2p::GroupId, s16, s16, u32, buffer<unknown, 0x21>)
         public ResultCode SendToOtherGroup(ServiceCtx context)


### PR DESCRIPTION
Stubs Ldn.Lp2p.ISfService: 776 (DestroyGroup).

This prevents a crash in Mario Kart Live: Home Circuit that would occur after exiting the kart pairing screen.