### PR TITLE
UI: New light theme colors

### DIFF
--- a/src/Ryujinx/Assets/Styles/Themes.xaml
+++ b/src/Ryujinx/Assets/Styles/Themes.xaml
@@ -8,7 +8,6 @@
             <Color x:Key="DataGridSelectionColor">#FF00FABB</Color>
             <Color x:Key="ThemeContentBackgroundColor">#FFF0F0F0</Color>
             <Color x:Key="ThemeControlBorderColor">#FFd6d6d6</Color>
-            <Color x:Key="SystemChromeWhiteColor">#FFFFFFFF</Color>
             <Color x:Key="ThemeForegroundColor">#FF000000</Color>
             <Color x:Key="MenuFlyoutPresenterBorderColor">#C1C1C1</Color>
             <Color x:Key="AppListBackgroundColor">#b3ffffff</Color>
@@ -26,7 +25,6 @@
             <Color x:Key="DataGridSelectionColor">#FF00FABB</Color>
             <Color x:Key="ThemeContentBackgroundColor">#dedede</Color>
             <Color x:Key="ThemeControlBorderColor">#c2c2c2</Color>
-            <Color x:Key="SystemChromeWhiteColor">#FFFFFFFF</Color>
             <Color x:Key="ThemeForegroundColor">#FF000000</Color>
             <Color x:Key="MenuFlyoutPresenterBorderColor">#C1C1C1</Color>
             <Color x:Key="AppListBackgroundColor">#b3ffffff</Color>
@@ -44,7 +42,6 @@
             <Color x:Key="DataGridSelectionColor">#FF00FABB</Color>
             <Color x:Key="ThemeContentBackgroundColor">#FF2D2D2D</Color>
             <Color x:Key="ThemeControlBorderColor">#FF505050</Color>
-            <Color x:Key="SystemChromeWhiteColor">#FFFFFFFF</Color>
             <Color x:Key="ThemeForegroundColor">#FFFFFFFF</Color>
             <Color x:Key="MenuFlyoutPresenterBorderColor">#3D3D3D</Color>
             <Color x:Key="AppListBackgroundColor">#0FFFFFFF</Color>

--- a/src/Ryujinx/Assets/Styles/Themes.xaml
+++ b/src/Ryujinx/Assets/Styles/Themes.xaml
@@ -4,10 +4,10 @@
         <ResourceDictionary x:Key="Default">
             <SolidColorBrush x:Key="DataGridSelectionBackgroundBrush"
                              Color="{DynamicResource DataGridSelectionColor}" />
+            <Color x:Key="ControlFillColorSecondary">#008AA8</Color>
             <Color x:Key="DataGridSelectionColor">#FF00FABB</Color>
             <Color x:Key="ThemeContentBackgroundColor">#FFF0F0F0</Color>
             <Color x:Key="ThemeControlBorderColor">#FFd6d6d6</Color>
-            <Color x:Key="TextOnAccentFillColorPrimary">#FFFFFFFF</Color>
             <Color x:Key="SystemChromeWhiteColor">#FFFFFFFF</Color>
             <Color x:Key="ThemeForegroundColor">#FF000000</Color>
             <Color x:Key="MenuFlyoutPresenterBorderColor">#C1C1C1</Color>
@@ -22,16 +22,20 @@
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="DataGridSelectionBackgroundBrush"
                              Color="{DynamicResource DataGridSelectionColor}" />
+            <Color x:Key="ControlFillColorSecondary">#3ddcff</Color>
             <Color x:Key="DataGridSelectionColor">#FF00FABB</Color>
-            <Color x:Key="ThemeContentBackgroundColor">#FFF0F0F0</Color>
-            <Color x:Key="ThemeControlBorderColor">#FFd6d6d6</Color>
-            <Color x:Key="TextOnAccentFillColorPrimary">#FFFFFFFF</Color>
+            <Color x:Key="ThemeContentBackgroundColor">#dedede</Color>
+            <Color x:Key="ThemeControlBorderColor">#c2c2c2</Color>
             <Color x:Key="SystemChromeWhiteColor">#FFFFFFFF</Color>
             <Color x:Key="ThemeForegroundColor">#FF000000</Color>
             <Color x:Key="MenuFlyoutPresenterBorderColor">#C1C1C1</Color>
             <Color x:Key="AppListBackgroundColor">#b3ffffff</Color>
             <Color x:Key="AppListHoverBackgroundColor">#80cccccc</Color>
             <Color x:Key="SecondaryTextColor">#A0000000</Color>
+            <Color x:Key="FavoriteApplicationIconColor">#fffcd12a</Color>
+            <Color x:Key="Switch">#13c3a4</Color>
+            <Color x:Key="Unbounded">#FFFF4554</Color>
+            <Color x:Key="Custom">#6483F5</Color>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Dark">
             <SolidColorBrush x:Key="DataGridSelectionBackgroundBrush"
@@ -40,13 +44,16 @@
             <Color x:Key="DataGridSelectionColor">#FF00FABB</Color>
             <Color x:Key="ThemeContentBackgroundColor">#FF2D2D2D</Color>
             <Color x:Key="ThemeControlBorderColor">#FF505050</Color>
-            <Color x:Key="TextOnAccentFillColorPrimary">#FFFFFFFF</Color>
             <Color x:Key="SystemChromeWhiteColor">#FFFFFFFF</Color>
             <Color x:Key="ThemeForegroundColor">#FFFFFFFF</Color>
             <Color x:Key="MenuFlyoutPresenterBorderColor">#3D3D3D</Color>
             <Color x:Key="AppListBackgroundColor">#0FFFFFFF</Color>
             <Color x:Key="AppListHoverBackgroundColor">#1EFFFFFF</Color>
             <Color x:Key="SecondaryTextColor">#A0FFFFFF</Color>
+            <Color x:Key="FavoriteApplicationIconColor">#fffcd12a</Color>
+            <Color x:Key="Switch">#FF2EEAC9</Color>
+            <Color x:Key="Unbounded">#FFFF4554</Color>
+            <Color x:Key="Custom">#6483F5</Color>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>


### PR DESCRIPTION
Light themes shouldn't be bright white.

Before:
![image](https://github.com/user-attachments/assets/833569e3-c0d0-4fbc-befc-c4c979071cbf)

After:
![image](https://github.com/user-attachments/assets/6779dfca-dbcd-4423-a52f-7d81fd8b2aa7)


Also removed unused color, added missing colors from "Default" to "Light" and "Dark", fixed users not highlighting in the Manage User Profiles window while using Light theme and changed the "Switch" color for light theme so it's easier to see, though it doesn't make much of a difference.

Closes #419 